### PR TITLE
Handle too long articles, convert html

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Posts the latest URLs from an RSS feed, optionally @mention-ing a role when post
 ## Invite
 
 By inviting this bot to your server you agree to the [terms and conditions](#privacy-statement) laid out in the privacy section of this document.  
-If you agree, invite to your server with [this link](https://discordapp.com/oauth2/authorize?client_id=343909688045469698&scope=bot&permissions=0x00014c00).
+~~If you agree, invite to your server with this link~~.
+*Temporarily unavailable due to scaling issues and the large amount of attention recently.*
 
 ## Setup
 

--- a/app/config.json
+++ b/app/config.json
@@ -1,6 +1,6 @@
 {
 	"maxCacheSize": 100,
 	"feedCheckInterval": 10000,
-	"charLimit": 1950,
+	"charLimit": 1920,
 	"viewFeedsPaginationLimit": 10
 }

--- a/app/config.json
+++ b/app/config.json
@@ -1,6 +1,6 @@
 {
 	"maxCacheSize": 100,
 	"feedCheckInterval": 10000,
-	"charLimit": 500,
+	"charLimit": 1950,
 	"viewFeedsPaginationLimit": 10
 }

--- a/app/models/feed-data.js
+++ b/app/models/feed-data.js
@@ -54,8 +54,8 @@ module.exports = class FeedData extends Core.BaseEmbeddedData {
         return new Promise((resolve, reject) => {
             channel.fetchMessages({ limit: 100 })
                 .then(messages => {
-					/* we want to push the links in oldest first, but discord.js returns messages newest first, so we need to reverse them
-					 * discord.js returns a map, and maps don't have .reverse methods, hence needing to spread the elements into an array first */
+          /* we want to push the links in oldest first, but discord.js returns messages newest first, so we need to reverse them
+           * discord.js returns a map, and maps don't have .reverse methods, hence needing to spread the elements into an array first */
                     [...messages.values()].reverse().forEach(m => this.cache(...GetUrls(m.content)));
                     resolve();
                 })

--- a/app/models/feed-data.js
+++ b/app/models/feed-data.js
@@ -111,7 +111,7 @@ function formatPost(article) {
     let message = "";
 
     if (article.title) message += `\n**${article.title}**`;
-    if (article.content) message += article.content.length > Config.charLimit ? "\nArticle content too long for a single Discord message!" : `\n${article.content}`;
+    if (article.content) message += article.content.length > Config.charLimit ? `\n${article.content.substr(0, Config.charLimit)}...` : `\n${article.content}`;
     if (article.link) message += `\n\n${normaliseUrlForDiscord(article.link)}`;
 
     return message;

--- a/app/models/feed-data.js
+++ b/app/models/feed-data.js
@@ -109,10 +109,20 @@ module.exports = class FeedData extends Core.BaseEmbeddedData {
 
 function formatPost(article) {
     let message = "";
+    let link = "";
+    let title = "";
 
-    if (article.title) message += `\n**${article.title}**`;
-    if (article.content) message += article.content.length > Config.charLimit ? `\n${article.content.substr(0, Config.charLimit)}...` : `\n${article.content}`;
-    if (article.link) message += `\n\n${normaliseUrlForDiscord(article.link)}`;
+    if (article.title) title = `\n**${article.title}**`;
+    if (article.link) link = `\n\n${normaliseUrlForDiscord(article.link)}`;
+
+    message += title;
+
+    if (article.content) {
+        let maxLen = Config.charLimit - title.length - link.length - 4;
+        message += article.content.length > maxLen ? `\n${article.content.substr(0, maxLen)}...` : `\n${article.content}`;
+    }
+
+    message += link;
 
     return message;
 }

--- a/app/models/feed-data.js
+++ b/app/models/feed-data.js
@@ -6,6 +6,7 @@ const Core = require("../../core");
 const DiscordUtil = require("../../core").util;
 const GetUrls = require("get-urls");
 const Url = require("url");
+const HtmlToText = require("html-to-text");
 
 // @ts-ignore
 const readFeed = url => promisify(require("rss-parser").parseURL)(url);
@@ -119,7 +120,8 @@ function formatPost(article) {
 
     if (article.content) {
         let maxLen = Config.charLimit - title.length - link.length - 4;
-        message += article.content.length > maxLen ? `\n${article.content.substr(0, maxLen)}...` : `\n${article.content}`;
+        let sanitized = HtmlToText.fromString(article.content);
+        message += sanitized.length > maxLen ? `\n${sanitized.substr(0, maxLen)}...` : `\n${sanitized}`;
     }
 
     message += link;

--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
 	"dependencies": {
 		"@types/node": "9.3.0",
 		"discord.js": "11.2.0",
-		"eslint": "4.16.0",
+		"eslint": "4.19.1",
 		"get-urls": "7.0.0",
 		"jsonfile": "3.0.1",
 		"rss-parser": "2.12.0",
-		"shortid": "2.2.8"
+		"shortid": "2.2.8",
+		"html-to-text": "3.3.0"
 	},
 	"name": "discord-bot-rss-feed",
 	"devDependencies": {},


### PR DESCRIPTION
I fixed 2 issues that I found while using this bot:

1. Articles that are too long give an annoying message rather than just trimming.
2. HTML code was rendered directly rather than converting to text first.