### PR TITLE
Use correct attribute to resolve host

### DIFF
--- a/app/models/feed-data.js
+++ b/app/models/feed-data.js
@@ -65,7 +65,7 @@ module.exports = class FeedData extends Core.BaseEmbeddedData {
     }
 
     fetchLatest(guild) {
-        const dnsPromise = resolveDns(Url.parse(this.url).host).then(() => this._doFetchRSS(guild));
+        const dnsPromise = resolveDns(Url.parse(this.url).hostname).then(() => this._doFetchRSS(guild));
 
         dnsPromise.catch(err => DiscordUtil.dateDebugError("Connection error: Can't resolve host", err.message || err));
 


### PR DESCRIPTION
Reason:
```js
> const url = require("url");
undefined
> url.parse("http://localhost:1080/rss.xml")
Url {
  protocol: 'http:',
  slashes: true,
  auth: null,
  host: 'localhost:1080',
  port: '1080',
  hostname: 'localhost',
  hash: null,
  search: null,
  query: null,
  pathname: '/rss.xml',
  path: '/rss.xml',
  href: 'http://localhost:1080/rss.xml' }
```
Before this commit it tries to resolve "localhost:1080" which is incorrect.